### PR TITLE
Fix typo in "RefTests" -- use lowercase "t"

### DIFF
--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -15,7 +15,7 @@ Everything you need to know to write good tests.
 * [Writing Javascript Tests](testharness.html) - Documentation for
   writing script-based tests.
 
-* [Writing RefTests](reftests.html) - Documentation for
+* [Writing Reftests](reftests.html) - Documentation for
   writing layout reftests.
 
 * [Writing Manual Tests](manual-test.html) - Documentation for writing


### PR DESCRIPTION
Fix typo: use lowercase "t" in "Reftests" (not "RefTests")

The correct spelling (with lowercase "t") can be seen in the title / header-text of the target-page itself, at http://testthewebforward.org/docs/reftests.html
