### PR TITLE
Make travis use correct branch, not always master

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ REPO = CONFIG["repo"]
 DESTINATION = CONFIG['destination']
 
 USERNAME = "w3c"
-SOURCE_BRANCH = "master"
+SOURCE_BRANCH = `git rev-parse --abbrev-ref HEAD`
 DESTINATION_BRANCH = "gh-pages"
 
 ENV["USERNAME"] = USERNAME


### PR DESCRIPTION
Without this change, travis fails with `error: pathspec 'master' did not match any file(s) known to git`.