### PR TITLE
discuss.md: Mention public-css-testsuite@w3.org

### DIFF
--- a/discuss.md
+++ b/discuss.md
@@ -9,6 +9,10 @@ layout: default
 * Mailing list: [public-test-infra@w3.org](mailto:public-test-infra@w3.org) ([archives](http://lists.w3.org/Archives/Public/public-test-infra/))
 * irc channel: [irc.w3.org#testing](irc://irc.w3.org:6667/#testing) ([web client](http://irc.w3.org/?channels=testing))
 
+### For CSS-specific discussion, questions, and issues:
+
+* Mailing list: [public-css-testsuite@w3.org](mailto:public-css-testsuite@w3.org) ([archives](http://lists.w3.org/Archives/Public/public-css-testsuite/))
+
 ## To subscribe to announcements:
 
 * Mailing list: [public-testtwf@w3.org](mailto:public-testtwf@w3.org) ([archives](http://lists.w3.org/Archives/Public/public-testtwf/))


### PR DESCRIPTION
The site currently doesn't mention this mailing list anywhere, even though it's the relevant mailing list for https://github.com/w3c/csswg-test