### PR TITLE
Add CSS links to "Writing Tests" nav sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,8 @@ docs:
       - testharness.html
       - reftests.html
       - manual-test.html
+      - css-naming.md
+      - css-metadata.md
       - test-templates.html
 
   - icons: play


### PR DESCRIPTION
Having to go to http://testthewebforward.org/docs/test-format-guidelines.html to find the links to these pages, and having to remember that that page is where those links live in the first place, is annoying. So this adds them to the sidebar where they can be more easily found.