### PR TITLE
Fix CSS links to "Writing Tests" nav sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,8 +54,8 @@ docs:
       - testharness.html
       - reftests.html
       - manual-test.html
-      - css-naming.md
-      - css-metadata.md
+      - css-naming.html
+      - css-metadata.html
       - test-templates.html
 
   - icons: play


### PR DESCRIPTION
I had meant to force push this fix to the earlier PR, but this repo took forever to clone and you're fast on the merge button :smile: 