### PR TITLE
Faithfully render braces in generated markup

### DIFF
--- a/_plugins/render_partial.rb
+++ b/_plugins/render_partial.rb
@@ -102,16 +102,7 @@ eos
         path = File.realpath(File.join(dir, file))
         validate_path(path, dir, context.registers[:site].safe)
 
-        begin
-          partial = Liquid::Template.parse(source(path, context))
-
-          context.stack do
-            context['include'] = parse_params(context) if @params
-            partial.render!(context)
-          end
-        rescue => e
-          raise IncludeTagError.new e.message, File.join(INCLUDES_DIR, @file)
-        end
+        source(path, context)
       end
 
       def validate_path(path, dir, safe)


### PR DESCRIPTION
By interpreting partials as Liquid templates, the `render_partial`
plugin strips content that happens to conform to that engine's syntax.
Specifically, the referenced documentation describes a substitution
syntax for Web Platform Test files which reserves the `{{` and `}}`
strings as delimiters for variable interpolation.

This plugin is only used to render content that is intended to stand
alone (i.e. without variable expansion), making the use of a templating
engine superfluous.

Remove the use of the rendering engine and emit the referenced text
directly.

Here's a comparison of the generated output before and after application of the patch:

```diff
$ git diff --no-index _site _site-fixed
diff --git a/_site/docs/lint-tool.html b/_site-fixed/docs/lint-tool.html
index 2beefce..ffc99ed 100644
--- a/_site/docs/lint-tool.html
+++ b/_site-fixed/docs/lint-tool.html
@@ -118,7 +118,7 @@ that&#39;s missing a <code>content</code> attribute; <strong>fix</strong>: add a
 with an appropriate value to the <code>&lt;meta name=&#39;variant&#39;...&gt;</code> element.</p></li>
 <li><p><strong>W3C-TEST.ORG</strong>: Test-file line has the string <code>w3c-test.org</code>; <strong>fix</strong>:
 either replace the <code>w3c-test.org</code> string with the expression
-<code>:</code> or a generic hostname like <code>example.org</code>.</p></li>
+<code>{{host}}:{{ports[http][0]}}</code> or a generic hostname like <code>example.org</code>.</p></li>
 </ul>
 
 <h2>Updating the whitelist</h2>
diff --git a/_site/docs/test-format-guidelines.html b/_site-fixed/docs/test-format-guidelines.html
index 75fed40..d0030fd 100644
--- a/_site/docs/test-format-guidelines.html
+++ b/_site-fixed/docs/test-format-guidelines.html
@@ -301,24 +301,29 @@ information in one of two ways:</p>
 <p>In order for the latter to work, a file must either have a name of the
 form <code>{name}.sub.{ext}</code> e.g. <code>example-test.sub.html</code> or be referenced
 through a URL containing <code>pipe=sub</code> in the query string
-e.g. <code>example-test.html?pipe=sub</code>. The substitution syntax uses ``
+e.g. <code>example-test.html?pipe=sub</code>. The substitution syntax uses <code>{{ }}</code>
 to delimit items for substitution. For example to substitute in
 the host name on which the tests are running, one would write:</p>
-
+<div class="highlight"><pre><code class="language-text" data-lang="text">{{host}}
+</code></pre></div>
 <p>As well as the host, one can get full domains, including subdomains
 using the <code>domains</code> dictionary. For example:</p>
-
+<div class="highlight"><pre><code class="language-text" data-lang="text">{{domains[www]}}
+</code></pre></div>
 <p>would be replaced by the fully qualified domain name of the <code>www</code>
 subdomain. Ports are also available on a per-protocol basis e.g.</p>
-
+<div class="highlight"><pre><code class="language-text" data-lang="text">{{ports[ws][0]}}
+</code></pre></div>
 <p>is replaced with the first (and only) websockets port, whilst</p>
-
+<div class="highlight"><pre><code class="language-text" data-lang="text">{{ports[http][1]}}
+</code></pre></div>
 <p>is replaced with the second HTTP port.</p>
 
 <p>The request URL itself can be used as part of the substitution using
 the <code>location</code> dictionary, which has entries matching the
 <code>window.location</code> API. For example</p>
-
+<div class="highlight"><pre><code class="language-text" data-lang="text">{{location[host]}}
+</code></pre></div>
 <p>is replaced by <code>hostname:port</code> for the current request.</p>
 
 <h3>Tests Requiring Special Headers</h3>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testtwf-website-src/40)
<!-- Reviewable:end -->
